### PR TITLE
Interceptor Deprecated, KindaLogger 구현

### DIFF
--- a/example/androidwithdsl/src/main/java/dohun/kim/kinda/androidwithdsl/CountViewModel.kt
+++ b/example/androidwithdsl/src/main/java/dohun/kim/kinda/androidwithdsl/CountViewModel.kt
@@ -1,7 +1,6 @@
 package dohun.kim.kinda.androidwithdsl
 
 import dohun.kim.kinda.kinda_android.KindaViewModel
-import dohun.kim.kinda.kinda_core.interceptor.LoggingInterceptor
 import dohun.kim.kinda.kinda_dsl.buildReducer
 import dohun.kim.kinda.kinda_dsl.buildSideEffectHandler
 import kotlinx.coroutines.delay
@@ -30,6 +29,5 @@ class CountViewModel : KindaViewModel<CountState, CountEvent, CountSideEffect>(
             delay(1000)
             CountEvent.Increase1000
         }
-    },
-    interceptors = setOf(LoggingInterceptor())
+    }
 )

--- a/example/hilt-retrofit-test/src/main/java/dohun/kim/kinda/hilt_retrofit_test/ExampleApplication.kt
+++ b/example/hilt-retrofit-test/src/main/java/dohun/kim/kinda/hilt_retrofit_test/ExampleApplication.kt
@@ -2,6 +2,14 @@ package dohun.kim.kinda.hilt_retrofit_test
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
+import dohun.kim.kinda.kinda_core.logging.KindaLoggerSetting
 
 @HiltAndroidApp
-class ExampleApplication : Application()
+class ExampleApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        KindaLoggerSetting.enableLogging()
+    }
+}

--- a/example/hilt-retrofit-test/src/main/java/dohun/kim/kinda/hilt_retrofit_test/github/GithubViewModel.kt
+++ b/example/hilt-retrofit-test/src/main/java/dohun/kim/kinda/hilt_retrofit_test/github/GithubViewModel.kt
@@ -6,7 +6,6 @@ import dohun.kim.kinda.hilt_retrofit_test.data.exception.ForbiddenException
 import dohun.kim.kinda.hilt_retrofit_test.data.exception.InternalErrorException
 import dohun.kim.kinda.kinda_android.KindaViewModel
 import dohun.kim.kinda.kinda_core.Event
-import dohun.kim.kinda.kinda_core.interceptor.LoggingInterceptor
 import dohun.kim.kinda.kinda_dsl.buildReducer
 import dohun.kim.kinda.kinda_dsl.buildSideEffectHandler
 
@@ -38,6 +37,5 @@ class GithubViewModel @ViewModelInject constructor(
                 GithubEvent.ToastEvent("잠시 후 다시 시도해주세요.")
             }
         }
-    },
-    interceptors = setOf(LoggingInterceptor())
+    }
 )

--- a/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/Kinda.kt
+++ b/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/Kinda.kt
@@ -1,6 +1,7 @@
 package dohun.kim.kinda.kinda_core
 
 import dohun.kim.kinda.kinda_core.interceptor.*
+import dohun.kim.kinda.kinda_core.logging.kindaLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -18,7 +19,11 @@ class Kinda<S : KindaState, E : KindaEvent, SE : KindaSideEffect> private constr
 
     fun intent(event: E) {
         interceptors.invokeBeforeReduce(state, event)
+        kindaLogger?.beforeReduce(state, event)
+
         val next = reducer.reduce(state, event)
+
+        kindaLogger?.afterReduce(next.state)
         interceptors.invokeAfterReduce(next.state, event)
 
         next.state?.let { state ->
@@ -28,9 +33,14 @@ class Kinda<S : KindaState, E : KindaEvent, SE : KindaSideEffect> private constr
 
         next.sideEffect?.let { sideEffect ->
             coroutineScope.launch(Dispatchers.IO) {
+
                 interceptors.invokeBeforeHandleSideEffect(state, sideEffect)
+                kindaLogger?.beforeHandleSideEffect(sideEffect)
+
                 sideEffectHandler?.handle(sideEffect)?.let { sideEffectResult ->
                     interceptors.invokeAfterHandleSideEffect(state, sideEffectResult, sideEffect)
+                    kindaLogger?.afterHandleSideEffect(sideEffectResult, sideEffect)
+
                     intent(sideEffectResult)
                 }
             }
@@ -60,12 +70,15 @@ class Kinda<S : KindaState, E : KindaEvent, SE : KindaSideEffect> private constr
         fun coroutineScope(coroutineScope: CoroutineScope) =
             apply { this.coroutineScope = coroutineScope }
 
+        @Deprecated("Interceptor deprecated since 1.3.0")
         fun addInterceptor(interceptor: Interceptor<S, E, SE>) =
             apply { this.interceptors.add(interceptor) }
 
+        @Deprecated("Interceptor deprecated since 1.3.0")
         fun removeInterceptor(interceptor: Interceptor<S, E, SE>) =
             apply { this.interceptors.remove(interceptor) }
 
+        @Deprecated("Interceptor deprecated since 1.3.0")
         fun addInterceptors(interceptors: Set<Interceptor<S, E, SE>>) =
             apply { this.interceptors.addAll(interceptors) }
 

--- a/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/interceptor/Interceptor.kt
+++ b/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/interceptor/Interceptor.kt
@@ -4,10 +4,10 @@ import dohun.kim.kinda.kinda_core.KindaEvent
 import dohun.kim.kinda.kinda_core.KindaSideEffect
 import dohun.kim.kinda.kinda_core.KindaState
 
+@Deprecated("Interceptor deprecated since 1.3.0")
 open class Interceptor<S : KindaState, E : KindaEvent, SE : KindaSideEffect> {
 
     open fun beforeReduce(before: S, event: E) {
-
     }
 
     open fun afterReduce(next: S?, event: E) {

--- a/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/interceptor/LoggingInterceptor.kt
+++ b/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/interceptor/LoggingInterceptor.kt
@@ -4,6 +4,7 @@ import dohun.kim.kinda.kinda_core.KindaEvent
 import dohun.kim.kinda.kinda_core.KindaSideEffect
 import dohun.kim.kinda.kinda_core.KindaState
 
+@Deprecated("Interceptor deprecated since 1.3.0")
 class LoggingInterceptor<S : KindaState, E : KindaEvent, SE : KindaSideEffect> : Interceptor<S, E, SE>() {
     companion object {
         private const val LOG_PREFIX = "Kinda log: "

--- a/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/logging/KindaLogger.kt
+++ b/kinda-core/src/main/java/dohun/kim/kinda/kinda_core/logging/KindaLogger.kt
@@ -1,0 +1,41 @@
+package dohun.kim.kinda.kinda_core.logging
+
+import dohun.kim.kinda.kinda_core.KindaEvent
+import dohun.kim.kinda.kinda_core.KindaSideEffect
+import dohun.kim.kinda.kinda_core.KindaState
+
+internal var kindaLogger: KindaLogger? = null
+
+object KindaLoggerSetting {
+
+    fun enableLogging(logPrefix: String = "Kinda log: ") {
+        kindaLogger = KindaLogger(logPrefix)
+    }
+
+    fun disableLogging() {
+        kindaLogger = null
+    }
+}
+
+internal class KindaLogger(
+    private val logPrefix: String
+) {
+
+    fun beforeReduce(before: KindaState, event: KindaEvent) {
+        println("${logPrefix}Event [${event::class.java.simpleName}]")
+        println("${logPrefix}\tFrom [${before}]")
+    }
+
+    fun afterReduce(next: KindaState?) {
+        println("${logPrefix}\tNext [${next ?: "No changes(null)"}]")
+    }
+
+    fun beforeHandleSideEffect(sideEffect: KindaSideEffect) {
+        println("${logPrefix}SideEffect start [${sideEffect::class.java.simpleName}]")
+    }
+
+    fun afterHandleSideEffect(sideEffectResult: KindaEvent, sideEffect: KindaSideEffect) {
+        println("${logPrefix}SideEffect end [${sideEffect::class.java.simpleName}]")
+        println("${logPrefix}\tSideEffectResult [${sideEffectResult::class.java.simpleName}]")
+    }
+}


### PR DESCRIPTION
closes #13 

Interceptor는 개념적으로 불필요하다고 판단하여 Deprecated.
기존 Interceptor를 구현하는 Logger를 대체할 수 있는 클래스 작성